### PR TITLE
Fixed bug which was preventing StringSet/NumberSet being parsed when in a map. Updated dev dependencies. Updated tests.

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,5 +20,8 @@
   "bugs": {
     "url": "https://github.com/big-math-solutions/parse-dynamodb-item/issues"
   },
-  "homepage": "https://github.com/big-math-solutions/parse-dynamodb-item#readme"
+  "homepage": "https://github.com/big-math-solutions/parse-dynamodb-item#readme",
+  "devDependencies": {
+    "mocha": "^5.1.1"
+  }
 }

--- a/parse/index.js
+++ b/parse/index.js
@@ -19,7 +19,9 @@ const parse = module.exports = (item) => Object.keys(item).reduce((reduced, prop
     else if (prop === 'N') return parseNumber(item[prop]);
     else if (prop === 'BOOL') return parseBool(item[prop]);
     else if (prop === 'NULL') return parseNull(item[prop]);
-    else if (item[prop].L || item[prop].SS || item[prop].NS) reduced[prop] = parseSet(item[prop].L);
+    else if (item[prop].L) reduced[prop] = parseSet(item[prop].L);
+    else if (item[prop].SS) reduced[prop] = parseSet(item[prop].SS);
+    else if (item[prop].NS) reduced[prop] = parseSet(item[prop].NS);
     else if (item[prop].B) reduced[prop] = parseBuffer(item[prop].B);
     else if (item[prop].S) reduced[prop] = parseString(item[prop].S);
     else if (item[prop].M) reduced[prop] = parseMap(item[prop].M, parse);

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -69,4 +69,22 @@ describe('test to parse', () => {
              array: [ 1, 2, 3, 4 ],
              map: { string: '2343' } } });
     });
+
+    it('should parse string set', () => {
+        const parsed = parse({
+            SS: [ 'one', 'two', 'three' ]
+        });
+        assert.deepEqual(parsed, [ 'one', 'two', 'three' ]);
+    });
+
+    it('should parse a map with a string set', () => {
+        const parsed = parse({
+            stringSet: {
+                SS: [ 'one', 'two', 'three' ]
+            }
+        });
+        assert.deepEqual(parsed, {
+            stringSet: [ 'one', 'two', 'three' ]
+        });
+    });
 });

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -87,4 +87,22 @@ describe('test to parse', () => {
             stringSet: [ 'one', 'two', 'three' ]
         });
     });
+
+    it('should parse number set', () => {
+        const parsed = parse({
+            NS: [ '1', '2', '3', '4.5' ]
+        });
+        assert.deepEqual(parsed, [ 1, 2, 3, 4.5 ]);
+    });
+
+    it('should parse a map with a number set', () => {
+        const parsed = parse({
+            numberSet: {
+                SS: [ '1', '2', '3', '4.5' ]
+            }
+        });
+        assert.deepEqual(parsed, {
+            numberSet: [ 1, 2, 3, 4.5 ]
+        });
+    });
 });


### PR DESCRIPTION
Like the title says; Parser now correctly parses StringSets and NumberSets when they are within a map. Updated test cases to cover new functionality.